### PR TITLE
Remove @octokit/core dependency

### DIFF
--- a/__tests__/apiwrapper.js
+++ b/__tests__/apiwrapper.js
@@ -1,4 +1,4 @@
-import { Octokit } from '@octokit/core';
+import { Octokit } from '@octokit/core'; // eslint-disable-line import/no-extraneous-dependencies
 import { paginateGraphql } from '@octokit/plugin-paginate-graphql';
 
 import { graphql, HttpResponse } from 'msw'; // https://mswjs.io/docs/getting-started

--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -1,4 +1,4 @@
-import { Octokit } from '@octokit/core';
+import { Octokit } from '@octokit/core'; // eslint-disable-line import/no-extraneous-dependencies
 import { paginateGraphql } from '@octokit/plugin-paginate-graphql';
 
 import { graphql, HttpResponse } from 'msw'; // https://mswjs.io/docs/getting-started

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 import core from '@actions/core';
 import github from '@actions/github';
 
-import { Octokit } from '@octokit/core';
+import { Octokit } from '@octokit/core'; // eslint-disable-line import/no-extraneous-dependencies
 import { paginateGraphql } from '@octokit/plugin-paginate-graphql';
 
 import { ApiWrapper } from './apiwrapper.js'; // eslint-disable-line import/extensions

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@actions/core": "*",
         "@actions/github": "*",
-        "@octokit/core": "*",
         "@octokit/graphql": "*",
         "@octokit/plugin-paginate-graphql": "*",
         "msw": "^2.2.3"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@actions/core": "*",
     "@actions/github": "*",
-    "@octokit/core": "*",
     "@octokit/graphql": "*",
     "@octokit/plugin-paginate-graphql": "*",
     "msw": "^2.2.3"


### PR DESCRIPTION
I found this: https://github.com/octokit/core.js/issues/666#issuecomment-1983778396

> You don't need `@octokit/core` when using `@actions/github`
>
> `@actions/github` requires v5 `@octokit/core`, which breaks newer `@octokit/core` versions defined as dependencies

Merging this will close the broken Dependabot PR, #74.

However, simply removing it from `package.json` does not work – ESLint will complain about extraneous dependencies. I also explored other options (like avoiding `import '@octokit/core` and using the GitHub client provided by `@actions/github` – see 80c3e6cf1b9940070ea73521bbdca65617b50db8 for details)