### PR TITLE
Error on duplicate titel inputs

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -31085,9 +31085,15 @@ const GraphQlOctokit = _octokit_core__WEBPACK_IMPORTED_MODULE_2__/* .Octokit.plu
 const octokit = new GraphQlOctokit({ auth: process.env.GITHUB_TOKEN });
 const apiWrapper = new _apiwrapper_js__WEBPACK_IMPORTED_MODULE_4__/* .ApiWrapper */ .X({ octokit });
 
+const hasDuplicates = (array) => new Set(array).size !== array.length;
+
 try {
   const titlesInput = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('project-titles');
   const titles = titlesInput.split(/\s+/);
+
+  if (hasDuplicates(titles)) {
+    throw new Error(`Duplicate project titles are not allowed: ${titles}`);
+  }
 
   // requries a github action event of type pull_request
   const {

--- a/index.js
+++ b/index.js
@@ -15,9 +15,15 @@ const GraphQlOctokit = Octokit.plugin(paginateGraphQL);
 const octokit = new GraphQlOctokit({ auth: process.env.GITHUB_TOKEN });
 const apiWrapper = new ApiWrapper({ octokit });
 
+const hasDuplicates = (array) => new Set(array).size !== array.length;
+
 try {
   const titlesInput = core.getInput('project-titles');
   const titles = titlesInput.split(/\s+/);
+
+  if (hasDuplicates(titles)) {
+    throw new Error(`Duplicate project titles are not allowed: ${titles}`);
+  }
 
   // requries a github action event of type pull_request
   const {


### PR DESCRIPTION
GitHub Action runs will break this action when the inputs contain duplicate project titles.

The correct way to address this is to reject the inputs and error with a comprehensive message.
 
Alternatively, we could de-duplicate the inputs silently and continue. However, this might produce other issues. E.g., the behaviour might no longer be deterministic if there were two same-titled projects existing in the same repo (which we do not want to allow). We should rather fail and fix the route cause (probably in `sync-repository-actions`).
 
We accept that `assign-to-repository-projects` fails if `sync-repository-actions` produces duplicate projects by mistake.