### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,9 @@ name: Test and build
 
 on: push 
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Potential fix for [https://github.com/babbel/assign-to-repository-projects/security/code-scanning/10](https://github.com/babbel/assign-to-repository-projects/security/code-scanning/10)

In general, the fix is to add an explicit `permissions` block that grants only the minimal access required by the workflow. Since this workflow only checks out code and runs Node-based CI tasks, it needs only read access to repository contents (and, optionally, to packages if your registry access uses `GITHUB_TOKEN`, but that is not shown here). The best minimal change is to add `permissions: contents: read` at the workflow level (top-level key) so it applies to all jobs, without altering any job steps or behavior.

Concretely, edit `.github/workflows/build.yml` and insert a `permissions` block near the top, alongside `name` and `on`. For example, after the `on: push` line add:

```yaml
permissions:
  contents: read
```

This does not require any imports or additional definitions; it is purely a YAML configuration change to the workflow file and will not change the functional behavior of the job other than restricting the implicit `GITHUB_TOKEN` capabilities.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
