### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -5,6 +5,8 @@
 # from other source files.
 # We need to make sure the checked-in `index.js` actually matches what we expect it to be.
 name: Check dist/
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -5,6 +5,7 @@
 # from other source files.
 # We need to make sure the checked-in `index.js` actually matches what we expect it to be.
 name: Check dist/
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Potential fix for [https://github.com/babbel/assign-to-repository-projects/security/code-scanning/11](https://github.com/babbel/assign-to-repository-projects/security/code-scanning/11)

In general, this problem is fixed by adding a `permissions` block either at the workflow root (applies to all jobs) or under the specific job, explicitly granting only the minimal required scopes. For a simple CI-style workflow that only checks out code, installs dependencies, runs builds, and uploads artifacts, `contents: read` is usually sufficient. Actions like `actions/checkout`, `actions/setup-node`, and `actions/upload-artifact` do not require write access to repository contents.

For this workflow, the best minimal change without affecting existing functionality is to add a workflow-level `permissions` block right after the `name:` declaration, setting `contents: read`. This will apply to the `check-dist` job (and any future jobs, unless overridden), ensuring that the `GITHUB_TOKEN` cannot perform writes to repository contents or other resources. No additional imports or code changes are needed, as this is purely a YAML configuration change in `.github/workflows/check-dist.yml`.

Concretely:
- Edit `.github/workflows/check-dist.yml`.
- Insert:

```yaml
permissions:
  contents: read
```

- Place it after line 7 (`name: Check dist/`) and before the `on:` block, following standard GitHub Actions examples and keeping indentation consistent.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
