### PR TITLE
Bump eslint from 10.4.1 to 10.5.0, Bump @vercel/ncc from 0.38.4 to 0.44.0, Bump eslint-plugin-n from 18.0.1 to 18.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@vercel/ncc": "*",
-        "eslint": "^10.4.1",
+        "eslint": "^10.5.0",
         "eslint-plugin-import-x": "^4.16.2",
         "eslint-plugin-n": "^18.0.1",
         "globals": "^17.6.0",
@@ -2746,11 +2746,14 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.1.tgz",
-      "integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.5.0.tgz",
+      "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
       "dev": true,
       "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@vercel/ncc": "*",
+        "@vercel/ncc": "^0.44.0",
         "eslint": "^10.5.0",
         "eslint-plugin-import-x": "^4.16.2",
         "eslint-plugin-n": "^18.1.0",
@@ -638,9 +638,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2930,9 +2930,9 @@
       }
     },
     "node_modules/eslint-plugin-import-x/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3075,9 +3075,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2086,10 +2086,11 @@
       ]
     },
     "node_modules/@vercel/ncc": {
-      "version": "0.38.4",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.4.tgz",
-      "integrity": "sha512-8LwjnlP39s08C08J5NstzriPvW1SP8Zfpp1BvC2sI35kPeZnHfxVkCwu4/+Wodgnd60UtT1n8K8zw+Mp7J9JmQ==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.44.0.tgz",
+      "integrity": "sha512-pHyI+bZokSgIscTKFSmpNk5vZzmOrb9RW0Vu4SRyqUvkJ0kgg3PzaZLLDVTFXhbUiCqg0/Eu8L4fKtgViA92kg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "ncc": "dist/ncc/cli.js"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@vercel/ncc": "*",
         "eslint": "^10.4.1",
         "eslint-plugin-import-x": "^4.16.2",
-        "eslint-plugin-n": "^18.0.1",
+        "eslint-plugin-n": "^18.1.0",
         "globals": "^17.6.0",
         "jest": "^30.4.2",
         "ts-jest": "^29.4.11"
@@ -2968,9 +2968,9 @@
       }
     },
     "node_modules/eslint-plugin-n": {
-      "version": "18.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-18.0.1.tgz",
-      "integrity": "sha512-q3ARhk+eZRc7myR0KHx+R3/GJeOHF+Ir6PK95Pu2tEX8Sl/4BIpmmVLva2kPrjC2gCmn6WHlHm+3yeo6Rxhycw==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-18.1.0.tgz",
+      "integrity": "sha512-hkUm9EtnFV2h2fE16jNVUfCVUqvPzI7fGLsFdun5lFt/pbmf2kCgDx6ymi9rx+NCUSggBmurJCZOfG20JBs/kg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@vercel/ncc": "*",
     "eslint": "^10.4.1",
     "eslint-plugin-import-x": "^4.16.2",
-    "eslint-plugin-n": "^18.0.1",
+    "eslint-plugin-n": "^18.1.0",
     "globals": "^17.6.0",
     "jest": "^30.4.2",
     "ts-jest": "^29.4.11"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@vercel/ncc": "*",
-    "eslint": "^10.4.1",
+    "eslint": "^10.5.0",
     "eslint-plugin-import-x": "^4.16.2",
     "eslint-plugin-n": "^18.0.1",
     "globals": "^17.6.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@vercel/ncc": "*",
+    "@vercel/ncc": "^0.44.0",
     "eslint": "^10.5.0",
     "eslint-plugin-import-x": "^4.16.2",
     "eslint-plugin-n": "^18.1.0",


### PR DESCRIPTION
> [!NOTE]
>This PR has been created with the [combine-prs](https://github.com/mdelapenya/gh-combine-prs) `gh` extension:

>gh combine-prs --query Bump --verbose --skip-pr-check --limit=40.

It combines the following PRs:

- Bump eslint from 10.4.1 to 10.5.0 (#261) @app/dependabot
- Bump @vercel/ncc from 0.38.4 to 0.44.0 (#262) @app/dependabot
- Bump eslint-plugin-n from 18.0.1 to 18.1.0 (#263) @app/dependabot

## Related Issues:

- Closes #261
- Closes #262
- Closes #263
